### PR TITLE
インベントリを追加

### DIFF
--- a/inventory.yml
+++ b/inventory.yml
@@ -1,0 +1,3 @@
+[host]
+ec2
+# .ssh/configに記述したホスト名を追加


### PR DESCRIPTION
- .ssh/configのホスト名をAnsible実行先ホストに指定